### PR TITLE
Fix notification windows ignoring BST/GMT offset

### DIFF
--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -15,6 +15,8 @@ type PostgresUsersRepository struct {
 	Db *DB
 }
 
+var londonLocation, _ = time.LoadLocation("Europe/London")
+
 func (r PostgresUsersRepository) FindUsersWithDisruptedTrains(ctx context.Context, train string) ([]*models.User, error) {
 
 	sql := `
@@ -24,11 +26,13 @@ func (r PostgresUsersRepository) FindUsersWithDisruptedTrains(ctx context.Contex
         		JOIN trains t ON nw.train_id = t.id
 		WHERE lower(t.line) = lower($1)
 		  	AND $2 = nw.weekday
-  			AND CURRENT_TIME BETWEEN nw.start_time AND nw.end_time`
+  			AND $3::time BETWEEN nw.start_time AND nw.end_time`
 
-	weekday := int(time.Now().UTC().Weekday())
+	now := time.Now().In(londonLocation)
+	weekday := int(now.Weekday())
+	currentTime := now.Format("15:04:05")
 
-	rows, err := r.Db.Query(ctx, sql, train, weekday)
+	rows, err := r.Db.Query(ctx, sql, train, weekday, currentTime)
 
 	defer rows.Close()
 

--- a/internal/database/users_test.go
+++ b/internal/database/users_test.go
@@ -7,15 +7,15 @@ import (
 )
 
 func TestPostgresUsersRepository_FindUsersWithDisruptedTrains(t *testing.T) {
-	day := int(time.Now().UTC().Weekday())
+	now := time.Now().In(londonLocation)
+	day := int(now.Weekday())
 
 	t.Run("Can find users that have trains that are considered disrupted", func(t *testing.T) {
 		connStr := CreatePostgresInstance(t)
 		db := NewTestDatabase(t, connStr)
 
-		currTime := time.Now().UTC()
-		startTime := currTime.Add(time.Minute * -10)
-		endTime := currTime.Add(time.Minute * 10)
+		startTime := now.Add(time.Minute * -10)
+		endTime := now.Add(time.Minute * 10)
 		db.Exec(t.Context(), `INSERT INTO users (id, last_notified, phone_number) VALUES (1, now(), 'number')`)
 		db.Exec(t.Context(), `INSERT INTO notification_windows (id, user_id, train_id, start_time, end_time, weekday) VALUES (1, 1, 1, $1, $2, $3)`, startTime, endTime, day)
 
@@ -28,14 +28,14 @@ func TestPostgresUsersRepository_FindUsersWithDisruptedTrains(t *testing.T) {
 		connStr := CreatePostgresInstance(t)
 		db := NewTestDatabase(t, connStr)
 
-		currTime := time.Now().UTC()
-		startTime := currTime.Add(time.Minute * -5)
-		endTime := currTime.Add(time.Minute * -5)
+		startTime := now.Add(time.Minute * -5)
+		endTime := now.Add(time.Minute * -5)
 		db.Exec(t.Context(), `INSERT INTO users (id, last_notified, phone_number) VALUES (1, now(), 'number')`)
 		db.Exec(t.Context(), `INSERT INTO notification_windows (id, user_id, train_id, start_time, end_time, weekday) VALUES (1, 1, 1, $1, $2, $3)`, startTime, endTime, day)
 
 		actual, _ := db.GetUsersRepository().FindUsersWithDisruptedTrains(t.Context(), "Avanti West Coast")
 
 		assert.Equal(t, 0, len(actual))
+
 	})
 }


### PR DESCRIPTION
## Summary
- Weekday and current time were both computed in UTC, meaning notification windows would fire an hour late during BST and could match the wrong day around midnight London time
- `notification_windows.start_time`/`end_time` are stored as wall-clock times (what the user intends), so the comparison must use London local time
- Switched to `Europe/London` for both weekday calculation and the time comparison passed to the SQL query (replacing `CURRENT_TIME` with a parameterised `$3::time`)

## Test plan
- [ ] Run integration tests with Docker to verify window matching works correctly
- [ ] Manually verify around a BST/GMT clock change (next one: October 2026)

🤖 Generated with [Claude Code](https://claude.com/claude-code)