### PR TITLE
Switch from disruption summary to description field

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -58,7 +58,7 @@ func (s DisruptionService) PollTrains(ctx context.Context) error {
 	}
 
 	for _, trainStatus := range status {
-		summary := trainStatus.LineStatuses[0].Disruption.Summary
+		summary := trainStatus.LineStatuses[0].Disruption.Description
 		err := s.TrainsRepo.UpdateTrainStatus(ctx, trainStatus.Name, trainStatus.LineStatuses[0].StatusSeverity, summary)
 
 		if err != nil {

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -73,7 +73,7 @@ func TestFindUsersAndNotify(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("Notification message uses line name and disruption summary", func(t *testing.T) {
+	t.Run("Notification message uses disruption description", func(t *testing.T) {
 		notifier := &TestNotifier{}
 		ds := NewTestDisruptionService(notifier)
 

--- a/internal/tfl/client.go
+++ b/internal/tfl/client.go
@@ -21,7 +21,7 @@ type TrainStatus struct {
 }
 
 type Disruption struct {
-	Summary string `json:"summary"`
+	Description string `json:"description"`
 }
 
 type LineStatus struct {

--- a/internal/tfl/client_test.go
+++ b/internal/tfl/client_test.go
@@ -25,7 +25,7 @@ func TestGetAllDisruptions(t *testing.T) {
 						"statusSeverityDescription": "Minor Delays",
 						"reason": "https://www.nationalrail.co.uk/service-disruptions/polesworth-20241204/",
 						"disruption": {
-						  "summary": "Minor delays between London Euston and Birmingham due to an earlier fault"
+						  "description": "Minor delays between London Euston and Birmingham due to an earlier fault"
 						}
 					  }
 					]
@@ -43,7 +43,7 @@ func TestGetAllDisruptions(t *testing.T) {
 						StatusSeverityDescription: "Minor Delays",
 						Reason:                    "https://www.nationalrail.co.uk/service-disruptions/polesworth-20241204/",
 						Disruption: Disruption{
-							Summary: "Minor delays between London Euston and Birmingham due to an earlier fault",
+							Description: "Minor delays between London Euston and Birmingham due to an earlier fault",
 						},
 					},
 				},


### PR DESCRIPTION
## Summary
- TFL does not populate `disruption.summary` in practice — verified against the live API during service hours
- `disruption.description` is the actual human-readable text (e.g. `"Circle Line: Minor delays anticlockwise only while we deal with a customer incident."`)
- Since description already includes the line name, no prefix is added in the notification message

## Test plan
- [ ] Verify a real disruption notification contains the description text

🤖 Generated with [Claude Code](https://claude.com/claude-code)