### PR TITLE
Fix error handling across service, database and TFL client

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -15,15 +15,15 @@ type DB struct {
 func NewDatabase(ctx context.Context, config *Config) (*DB, error) {
 	db, err := Connect(ctx, config)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize postgres: %v", err)
+		return nil, fmt.Errorf("unable to initialize postgres: %w", err)
 	}
 	err = db.RunMigrate()
 	if err != nil {
-		return nil, fmt.Errorf("unable to run migration: %v", err)
+		return nil, fmt.Errorf("unable to run migration: %w", err)
 	}
 	err = db.RunSeed(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("unable to run seed: %v", err)
+		return nil, fmt.Errorf("unable to run seed: %w", err)
 	}
 
 	return db, nil

--- a/internal/database/trains.go
+++ b/internal/database/trains.go
@@ -43,12 +43,10 @@ func (r PostgresTrainsRepository) FindTrainsThatAreWithinWindow(ctx context.Cont
 	weekday := int(time.Now().UTC().Weekday())
 
 	rows, err := r.Db.Query(ctx, sql, weekday)
-
-	defer rows.Close()
-
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 
 	var trains []*models.Train
 

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -33,12 +33,10 @@ func (r PostgresUsersRepository) FindUsersWithDisruptedTrains(ctx context.Contex
 	currentTime := now.Format("15:04:05")
 
 	rows, err := r.Db.Query(ctx, sql, train, weekday, currentTime)
-
-	defer rows.Close()
-
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 
 	var users []*models.User
 

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"github.com/kushturner/tfl-alerts/internal/database"
 	"github.com/kushturner/tfl-alerts/internal/notification"
 	"github.com/kushturner/tfl-alerts/internal/tfl"
@@ -25,7 +26,10 @@ func NewDisruptionService(trainsRepo database.TrainsRepository, usersRepo databa
 }
 
 func (s DisruptionService) FindUsersAndNotify(ctx context.Context) error {
-	trains, _ := s.TrainsRepo.FindTrainsThatAreWithinWindow(ctx)
+	trains, err := s.TrainsRepo.FindTrainsThatAreWithinWindow(ctx)
+	if err != nil {
+		return fmt.Errorf("finding trains within window: %w", err)
+	}
 
 	for _, t := range trains {
 		if t.HasSameSeverity() {
@@ -33,16 +37,20 @@ func (s DisruptionService) FindUsersAndNotify(ctx context.Context) error {
 		}
 
 		if t.IsDisrupted() {
-			users, _ := s.UsersRepo.FindUsersWithDisruptedTrains(ctx, t.Line)
+			users, err := s.UsersRepo.FindUsersWithDisruptedTrains(ctx, t.Line)
+			if err != nil {
+				return fmt.Errorf("finding users for train %s: %w", t.Line, err)
+			}
+
 			for _, u := range users {
 				msg := t.NotificationMessage()
 
 				if err := s.Notifier.Notify(msg, u.Number); err != nil {
-					log.Printf("unable to notify user: %v", err)
+					log.Printf("unable to notify user %d: %v", u.ID, err)
 				}
 
 				if err := s.UsersRepo.UpdateUserLastNotified(ctx, u.ID); err != nil {
-					log.Printf("unable to update user: %v", err)
+					log.Printf("unable to update last notified for user %d: %v", u.ID, err)
 				}
 			}
 		}
@@ -52,17 +60,14 @@ func (s DisruptionService) FindUsersAndNotify(ctx context.Context) error {
 
 func (s DisruptionService) PollTrains(ctx context.Context) error {
 	status, err := s.Tfl.AllCurrentDisruptions()
-
 	if err != nil {
-		log.Printf("unable to get all current disruptions: %v", err)
+		return fmt.Errorf("fetching disruptions: %w", err)
 	}
 
 	for _, trainStatus := range status {
 		summary := trainStatus.LineStatuses[0].Disruption.Description
-		err := s.TrainsRepo.UpdateTrainStatus(ctx, trainStatus.Name, trainStatus.LineStatuses[0].StatusSeverity, summary)
-
-		if err != nil {
-			log.Printf("unable to update train status: %v", err)
+		if err := s.TrainsRepo.UpdateTrainStatus(ctx, trainStatus.Name, trainStatus.LineStatuses[0].StatusSeverity, summary); err != nil {
+			log.Printf("unable to update train status for %s: %v", trainStatus.Name, err)
 		}
 	}
 

--- a/internal/tfl/client.go
+++ b/internal/tfl/client.go
@@ -40,7 +40,7 @@ func NewClient(cfg *Config) (Client, error) {
 func (c *Client) AllCurrentDisruptions() ([]TrainStatus, error) {
 	resp, err := c.get(c.url + "/Line/Mode/" + trainTypes + "/Status?detail=true")
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch status: %v", err)
+		return nil, fmt.Errorf("failed to fetch status: %w", err)
 	}
 
 	defer resp.Body.Close()
@@ -52,20 +52,19 @@ func (c *Client) AllCurrentDisruptions() ([]TrainStatus, error) {
 	var t []TrainStatus
 
 	if err := json.NewDecoder(resp.Body).Decode(&t); err != nil {
-		return nil, fmt.Errorf("failed to decode disruptions: %v", err)
+		return nil, fmt.Errorf("failed to decode disruptions: %w", err)
 	}
 
 	return t, nil
 }
 
 func (c *Client) get(url string) (*http.Response, error) {
-
 	req, err := http.NewRequest("GET", url, nil)
-	req.Header.Set("User-Agent", "")
-
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %v", err)
+		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
+
+	req.Header.Set("User-Agent", "")
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -16,18 +16,30 @@ import (
 func main() {
 	cfg, err := config.LoadAppConfig()
 	if err != nil {
-		log.Panicf("unable to load config: %v", err)
+		log.Fatalf("unable to load config: %v", err)
 	}
 
 	ctx := context.Background()
 
-	store, _ := database.NewDatabase(ctx, cfg.DatabaseConfig)
+	store, err := database.NewDatabase(ctx, cfg.DatabaseConfig)
+	if err != nil {
+		log.Fatalf("unable to initialise database: %v", err)
+	}
 	defer store.Close()
+
 	usersRepo := store.GetUsersRepository()
 	trainsRepo := store.GetTrainsRepository()
+
 	twilio := notification.NewTwilioClient(cfg.TwilioConfig)
-	smsNotifier, _ := notification.NewSMSNotifier(twilio)
-	tflClient, _ := tfl.NewClient(cfg.TflConfig)
+	smsNotifier, err := notification.NewSMSNotifier(twilio)
+	if err != nil {
+		log.Fatalf("unable to initialise SMS notifier: %v", err)
+	}
+
+	tflClient, err := tfl.NewClient(cfg.TflConfig)
+	if err != nil {
+		log.Fatalf("unable to initialise TFL client: %v", err)
+	}
 
 	svc := service.NewDisruptionService(trainsRepo, usersRepo, smsNotifier, tflClient)
 
@@ -40,8 +52,12 @@ func main() {
 	for {
 		select {
 		case <-ticker.C:
-			_ = svc.PollTrains(ctx)
-			_ = svc.FindUsersAndNotify(ctx)
+			if err := svc.PollTrains(ctx); err != nil {
+				log.Printf("poll trains: %v", err)
+			}
+			if err := svc.FindUsersAndNotify(ctx); err != nil {
+				log.Printf("find users and notify: %v", err)
+			}
 		case <-sigChan:
 			log.Println("stopping service...")
 			return


### PR DESCRIPTION
## What changed and why

**Panic risks fixed**
- `defer rows.Close()` was called before the error check in `users.go` and `trains.go` — if `Query` returned an error, `rows` would be nil and the deferred call would panic. Moved defer after the nil check.
- In `tfl/client.go`, `req.Header.Set` was called before checking the error from `http.NewRequest` — if request creation failed, `req` would be nil and this would panic. Moved the nil check first.

**Error propagation aligned with CLAUDE.md**
- `main.go` was discarding errors from `NewDatabase`, `NewSMSNotifier`, and `NewClient` with `_`. These are unrecoverable startup failures — now `log.Fatal` on each.
- `service.go` was silently discarding errors from `FindTrainsThatAreWithinWindow` and `FindUsersWithDisruptedTrains`. These now propagate up and are logged once in `main.go`'s ticker loop.
- `PollTrains` was logging the TFL fetch error then falling through to range over a nil slice. Now returns the error immediately.
- Per-item loop errors (notify user, update last notified, update train status) still log-and-continue — aborting the whole loop for one item would be wrong.
- Replaced `log.Panicf` with `log.Fatalf` for the config load failure in `main.go`.

**Error chain fixed**
- `%v` replaced with `%w` in `tfl/client.go` and `database/database.go` so `errors.Is`/`errors.As` work correctly through wrapped errors.

## Not included
Deferred: `londonLocation` loaded at package level with discarded error in `users.go` — tracked separately in a GitHub issue.